### PR TITLE
Add boundary inclusivity on `isBetween`

### DIFF
--- a/packages/time/lib/inclusivity.ts
+++ b/packages/time/lib/inclusivity.ts
@@ -1,0 +1,1 @@
+export type Inclusivity = '[]' | '[)' | '(]' | '()'

--- a/packages/time/lib/tests/time.unit.test.ts
+++ b/packages/time/lib/tests/time.unit.test.ts
@@ -253,6 +253,201 @@ describe('Time class', () => {
     })
   })
 
+  describe('isBetween', () => {
+    it('Time between two inclusive boundaries returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(true)
+    })
+
+    it('Time same as both inclusive boundaries returns true', () => {
+      const lowerBound = new Time('12:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(true)
+    })
+
+    it('Time same as lower boundary between two inclusive boundaries returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('00:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(true)
+    })
+
+    it('Time same as upper boundary between two inclusive boundaries returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('23:59:59')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(true)
+    })
+
+    it('Time before two inclusive boundaries returns false', () => {
+      const lowerBound = new Time('12:00:01')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(false)
+    })
+
+    it('Time after two inclusive boundaries returns false', () => {
+      const lowerBound = new Time('11:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:01')
+
+      expect(time.isBetween(lowerBound,upperBound)).toBe(false)
+    })
+
+    it('Time between two exclusive boundaries returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(true)
+    })
+
+    it('Time same as both exclusive boundaries returns false', () => {
+      const lowerBound = new Time('12:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(false)
+    })
+
+    it('Time same as lower boundary between two exclusive boundaries returns false', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('00:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(false)
+    })
+
+    it('Time same as upper boundary between two exclusive boundaries returns false', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('23:59:59')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(false)
+    })
+
+    it('Time before two exclusive boundaries returns false', () => {
+      const lowerBound = new Time('12:00:01')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(false)
+    })
+
+    it('Time after two exclusive boundaries returns false', () => {
+      const lowerBound = new Time('11:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:01')
+
+      expect(time.isBetween(lowerBound,upperBound, '()')).toBe(false)
+    })
+
+    it('Time between an exclusive lowerbound and inclusive upperbound returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(true)
+    })
+
+    it('Time same as both an exclusive lowerbound and inclusive upperbound returns false', () => {
+      const lowerBound = new Time('12:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(false)
+    })
+
+    it('Time same as lower boundary between an exclusive lowerbound and inclusive upperbound returns false', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('00:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(false)
+    })
+
+    it('Time same as upper boundary between an exclusive lowerbound and inclusive upperbound returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('23:59:59')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(true)
+    })
+
+    it('Time before an exclusive lowerbound and inclusive upperbound returns false', () => {
+      const lowerBound = new Time('12:00:01')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(false)
+    })
+
+    it('Time after an exclusive lowerbound and inclusive upperbound returns false', () => {
+      const lowerBound = new Time('11:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:01')
+
+      expect(time.isBetween(lowerBound,upperBound, '(]')).toBe(false)
+    })
+
+
+    it('Time between an inclusive lowerbound and exclusive upperbound returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(true)
+    })
+
+    it('Time same as both an inclusive lowerbound and exclusive upperbound returns false', () => {
+      const lowerBound = new Time('12:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(false)
+    })
+
+    it('Time same as lower boundary between an inclusive lowerbound and exclusive upperbound returns true', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('00:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(true)
+    })
+
+    it('Time same as upper boundary between an inclusive lowerbound and exclusive upperbound returns false', () => {
+      const lowerBound = new Time('00:00:00')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('23:59:59')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(false)
+    })
+
+    it('Time before an inclusive lowerbound and exclusive upperbound returns false', () => {
+      const lowerBound = new Time('12:00:01')
+      const upperBound = new Time('23:59:59')
+      const time = new Time('12:00:00')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(false)
+    })
+
+    it('Time after an inclusive lowerbound and exclusive upperbound returns false', () => {
+      const lowerBound = new Time('11:00:00')
+      const upperBound = new Time('12:00:00')
+      const time = new Time('12:00:01')
+
+      expect(time.isBetween(lowerBound,upperBound, '[)')).toBe(false)
+    })
+  })
+
   describe('equals', () => {
     it('When comparing times, it should determine the equality correctly', () => {
       const time = new Time('10:10:10')

--- a/packages/time/lib/time.ts
+++ b/packages/time/lib/time.ts
@@ -1,6 +1,7 @@
 import { SECONDS_PER_HOUR, SECONDS_PER_MINUTE } from './constants.js'
 import { InvalidBounds, InvalidHours, InvalidMinutes, InvalidSeconds, InvalidTimeString } from './time-error.js'
 import {PlainTimeObject} from "./plain-time-object.type.js";
+import {Inclusivity} from "./inclusivity.js";
 
 export class Time {
   public static STRING_FORMAT = 'hh:mm:ss'
@@ -122,15 +123,22 @@ export class Time {
   }
 
   /**
-   * @param lowerBound must be before upperBound
-   * @param upperBound must be after lowerBound
+   * @param lowerBound must be before or same as upperBound
+   * @param upperBound must be after or same as lowerBound
    * @throws InvalidBounds
    */
-  public isBetween (lowerBound: Time, upperBound: Time): boolean {
-    if (lowerBound.isAfterOrEqual(upperBound)) {
+  public isBetween (lowerBound: Time, upperBound: Time, inclusivity: Inclusivity = '[]'): boolean {
+    if (lowerBound.isAfter(upperBound)) {
       throw new InvalidBounds(lowerBound, upperBound)
     }
-    return this.isAfter(lowerBound) && this.isBefore(upperBound)
+
+    switch (inclusivity){
+      case "[]": return this.isAfterOrEqual(lowerBound) && this.isBeforeOrEqual(upperBound)
+      case "[)": return this.isAfterOrEqual(lowerBound) && this.isBefore(upperBound)
+      case "(]": return this.isAfter(lowerBound) && this.isBeforeOrEqual(upperBound)
+      case "()": return this.isAfter(lowerBound) && this.isBefore(upperBound)
+      default:   return inclusivity
+    }
   }
 
   public equals (other: Time): boolean {


### PR DESCRIPTION
Check tests in detail for defined behaviour on weird boundaries like: (x-x] (defaults to false)
Breaking changes: default to inclusive, previously exclusive.